### PR TITLE
Reduce port names to match 15char API max

### DIFF
--- a/kubernetes-config/locust-master-controller.yaml
+++ b/kubernetes-config/locust-master-controller.yaml
@@ -42,12 +42,12 @@ spec:
               key: TARGET_HOST
               value: http://workload-simulation-webapp.appspot.com
           ports:
-            - name: locust-master-web
+            - name: loc-master-web
               containerPort: 8089
               protocol: TCP
-            - name: locust-master-port-1
+            - name: loc-master-p1
               containerPort: 5557
               protocol: TCP
-            - name: locust-master-port-2
+            - name: loc-master-p2
               containerPort: 5558
               protocol: TCP

--- a/kubernetes-config/locust-master-service.yaml
+++ b/kubernetes-config/locust-master-service.yaml
@@ -23,17 +23,17 @@ metadata:
 spec:
   ports:
     - port: 8089
-      targetPort: locust-master-web
+      targetPort: loc-master-web
       protocol: TCP
-      name: locust-master-web
+      name: loc-master-web
     - port: 5557
-      targetPort: locust-master-port-1
+      targetPort: loc-master-p1
       protocol: TCP
-      name: locust-master-port-1
+      name: loc-master-p1
     - port: 5558
-      targetPort: locust-master-port-2
+      targetPort: loc-master-p2
       protocol: TCP
-      name: locust-master-port-2
+      name: loc-master-p2
   selector:
     name: locust
     role: master


### PR DESCRIPTION
Kube's v1 API requires port names be <= 15 chars. This PR changes names (and references) to match that.