### PR TITLE
IIUC the "key" property is no longer part of the schema

### DIFF
--- a/kubernetes-config/locust-master-controller.yaml
+++ b/kubernetes-config/locust-master-controller.yaml
@@ -36,10 +36,8 @@ spec:
           image: gcr.io/cloud-solutions-images/locust-tasks:latest
           env:
             - name: LOCUST_MODE
-              key: LOCUST_MODE
               value: master
             - name: TARGET_HOST
-              key: TARGET_HOST
               value: http://workload-simulation-webapp.appspot.com
           ports:
             - name: loc-master-web


### PR DESCRIPTION
Removing the key properties returns this configuration to a working state.
