### PR TITLE
IIUC the "key" property is no longer part of the schema

### DIFF
--- a/kubernetes-config/locust-worker-controller.yaml
+++ b/kubernetes-config/locust-worker-controller.yaml
@@ -36,11 +36,8 @@ spec:
           image: gcr.io/cloud-solutions-images/locust-tasks:latest
           env:
             - name: LOCUST_MODE
-              key: LOCUST_MODE
               value: worker
             - name: LOCUST_MASTER
-              key: LOCUST_MASTER
               value: locust-master
             - name: TARGET_HOST
-              key: TARGET_HOST
               value: http://workload-simulation-webapp.appspot.com


### PR DESCRIPTION
Removing the "key" property returns this configuration to a working state.
