### PR TITLE
gcloud app is not in preview anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tutorial demonstrates how to conduct distributed load testing using [Kubern
 
 **Note:** when installing the Google Cloud SDK you will need to enable the following additional components:
 
-* `App Engine Command Line Interface (Preview)`
+* `App Engine Command Line Interface`
 * `App Engine SDK for Python and PHP`
 * `Compute Engine Command Line Interface`
 * `Developer Preview gcloud Commands`
@@ -24,9 +24,9 @@ Before continuing, you can also set your preferred zone and project:
 
 ## Deploy Web Application
 
-The `sample-webapp` folder contains a simple Google App Engine Python application as the "system under test". To deploy the application to your project use the `gcloud preview app deploy` command.
+The `sample-webapp` folder contains a simple Google App Engine Python application as the "system under test". To deploy the application to your project use the `gcloud app deploy` command.
 
-    $ gcloud preview app deploy sample-webapp/app.yaml --project=PROJECT-ID --set-default
+    $ gcloud app deploy sample-webapp/app.yaml --project=PROJECT-ID
 
 **Note:** you will need the URL of the deployed sample web application when deploying the `locust-master` and `locust-worker` controllers.
 


### PR DESCRIPTION
eg.:
WARNING: The `gcloud preview app` command group is deprecated; please use the `gcloud app` commands instead.
Google Cloud SDK 128.0.0
