### PR TITLE
remove field 'key' in spec env from locust controller yaml

### DIFF
--- a/kubernetes-config/locust-master-controller.yaml
+++ b/kubernetes-config/locust-master-controller.yaml
@@ -36,10 +36,8 @@ spec:
           image: gcr.io/cloud-solutions-images/locust-tasks:latest
           env:
             - name: LOCUST_MODE
-              key: LOCUST_MODE
               value: master
             - name: TARGET_HOST
-              key: TARGET_HOST
               value: http://workload-simulation-webapp.appspot.com
           ports:
             - name: loc-master-web

--- a/kubernetes-config/locust-worker-controller.yaml
+++ b/kubernetes-config/locust-worker-controller.yaml
@@ -36,11 +36,8 @@ spec:
           image: gcr.io/cloud-solutions-images/locust-tasks:latest
           env:
             - name: LOCUST_MODE
-              key: LOCUST_MODE
               value: worker
             - name: LOCUST_MASTER
-              key: LOCUST_MASTER
               value: locust-master
             - name: TARGET_HOST
-              key: TARGET_HOST
               value: http://workload-simulation-webapp.appspot.com


### PR DESCRIPTION
Since "key" field seems not to be supported, I deleted it from the yaml files.
I have confirmed that it worked with kubectl v1.8.0.

Thanks