### PR TITLE
Update README to more closely match cloud.google.com docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ After the Locust workers are deployed, you can return to the Locust master web i
                 --num-nodes "3" \
                 --enable-autoscaling --min-nodes "3" \
                 --max-nodes "10" \
+                --scopes=logging-write,storage-ro \
                 --addons HorizontalPodAutoscaling,HttpLoadBalancing
 
         $ gcloud container clusters get-credentials $CLUSTER \


### PR DESCRIPTION
Specifically, the cluster needs `storage-ro` scope in order to pull the docker image.

https://cloud.google.com/solutions/distributed-load-testing-using-gke