### PR TITLE
Upgrade deprecated api version of deployments

### DIFF
--- a/kubernetes-config/locust-master-controller.yaml
+++ b/kubernetes-config/locust-master-controller.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-apiVersion: "extensions/v1beta1"
+apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: locust-master

--- a/kubernetes-config/locust-worker-controller.yaml
+++ b/kubernetes-config/locust-worker-controller.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: "extensions/v1beta1"
+apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   name: locust-worker


### PR DESCRIPTION
Since Kubernetes version 1.16, "extensions/v1beta1" has been deprecated.
Therefore, I have fix the api version of deployment resources.

refs: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/